### PR TITLE
following cases to safe. ?queryparam[a][b]=value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comma-separated-query-param",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "query string parser which makes comma-separated string into array",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ class CommaSeparatedParameterListParser {
 		Object.keys(req.query).forEach(key => {
 			if (this.isTarget(key)) {
 				const val = req.query[key];
-
+				if (typeof val === "object") return;
 				const values = (Array.isArray(val))
 					? val.map(e => this.split(e))
 						.reduce((acc, v) => acc.concat(v), [] as string[])


### PR DESCRIPTION
When the argument is an object, I was made to not be an error in the split function.
